### PR TITLE
load and merge user Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Celestite supports running the Vite dev server over HTTPS, useful for tunneled c
    ```
 
 4. Enable in configuration:
+
    ```crystal
    Celestite.initialize(
      dev_secure: true,
@@ -267,18 +268,21 @@ NODE_ENV=production NODE_PORT=4000 \
 
 ## Configuration Options
 
-| Option                  | Default  | Description                              |
-| ----------------------- | -------- | ---------------------------------------- |
-| `engine`                | `Svelte` | Rendering engine (currently only Svelte) |
-| `component_dir`         | -        | Path to your Svelte components           |
-| `layout_dir`            | -        | Path to HTML layout templates            |
-| `build_dir`             | -        | Output directory for production builds   |
-| `port`                  | `4000`   | Bun SSR server port                      |
-| `vite_port`             | `5173`   | Vite dev server port (development only)  |
-| `dev_secure`            | `false`  | Enable HTTPS for dev server              |
-| `dev_client_protocol`   | -        | Override the browser-facing dev protocol |
-| `dev_client_base`       | -        | Prefix browser-facing dev assets         |
-| `disable_a11y_warnings` | `false`  | Suppress Svelte accessibility warnings   |
+| Option                  | Default  | Description                                            |
+| ----------------------- | -------- | ------------------------------------------------------ |
+| `engine`                | `Svelte` | Rendering engine (currently only Svelte)               |
+| `component_dir`         | -        | Path to your Svelte components                         |
+| `layout_dir`            | -        | Path to HTML layout templates                          |
+| `build_dir`             | -        | Output directory for production builds                 |
+| `port`                  | `4000`   | Bun SSR server port                                    |
+| `vite_port`             | `5173`   | Vite dev server port (development only)                |
+| `dev_secure`            | `false`  | Enable HTTPS for dev server                            |
+| `dev_client_protocol`   | -        | Override the browser-facing dev protocol               |
+| `dev_client_base`       | -        | Prefix browser-facing dev assets                       |
+| `disable_a11y_warnings` | `false`  | Suppress Svelte accessibility warnings                 |
+| `vite_config_path`      | -        | Path to custom Vite config file (relative to app root) |
+
+**Note**: Celestite always provides its own Svelte plugin with SSR-specific settings. User-provided Svelte plugins are automatically removed during config merging.
 
 ## Roadmap
 

--- a/src/celestite/config.cr
+++ b/src/celestite/config.cr
@@ -10,8 +10,9 @@ module Celestite
     getter layout_dir : String?
     getter build_dir : String?
     getter disable_a11y_warnings : Bool
+    getter vite_config_path : String?
 
-    def initialize(@env = "development", @port = 4000, @vite_port = 5173, @dev_secure = false, @engine = Celestite::Engine::Svelte, @root_dir = nil, @component_dir = nil, @layout_dir = nil, @build_dir = nil, @disable_a11y_warnings = false)
+    def initialize(@env = "development", @port = 4000, @vite_port = 5173, @dev_secure = false, @engine = Celestite::Engine::Svelte, @root_dir = nil, @component_dir = nil, @layout_dir = nil, @build_dir = nil, @disable_a11y_warnings = false, @vite_config_path = nil)
     end
   end
 end

--- a/src/celestite/renderer.cr
+++ b/src/celestite/renderer.cr
@@ -40,6 +40,7 @@ module Celestite
             args << "LAYOUT_DIR=#{@config.layout_dir} " if @config.layout_dir
             args << "BUILD_DIR=#{@config.build_dir} " if @config.build_dir
             args << "DISABLE_A11Y_WARNINGS=#{@config.disable_a11y_warnings} "
+            args << "VITE_CONFIG_PATH=#{@config.vite_config_path} " if @config.vite_config_path
           end
           str << "make -r " << @config.env << " "
           str << common_args

--- a/src/svelte-scripts/load-user-config.js
+++ b/src/svelte-scripts/load-user-config.js
@@ -1,0 +1,61 @@
+import { loadConfigFromFile } from "vite";
+import { resolve } from "path";
+
+/**
+ * Checks if a plugin is the Svelte plugin from @sveltejs/vite-plugin-svelte.
+ * Handles both named exports (svelte()) and direct imports.
+ */
+function isSveltePlugin(plugin) {
+  if (!plugin) return false;
+  // Check by name property that Svelte plugin sets
+  return plugin.name === "vite-plugin-svelte" || plugin.name === "svelte";
+}
+
+/**
+ * Removes Svelte plugins from user config to prevent duplication.
+ * Celestite always adds its own Svelte plugin with specific settings.
+ */
+export function filterSveltePlugin(userConfig) {
+  if (!userConfig || !userConfig.plugins) return userConfig;
+  return {
+    ...userConfig,
+    plugins: userConfig.plugins.filter(p => !isSveltePlugin(p))
+  };
+}
+
+/**
+ * Loads the user's Vite config from VITE_CONFIG_PATH.
+ *
+ * Resolves the path against ROOT_DIR (set by Celestite's Crystal renderer)
+ * so relative paths work regardless of the process's cwd.
+ *
+ * @param {object} configEnv - Vite ConfigEnv: { mode, command, isSsrBuild }
+ * @returns {Promise<import('vite').UserConfig | null>}
+ */
+export async function loadUserViteConfig(configEnv) {
+  const viteConfigPath = process.env.VITE_CONFIG_PATH;
+  if (!viteConfigPath) return null;
+
+  const rootDir = process.env.ROOT_DIR;
+  if (!rootDir) {
+    console.error("[celestite] ROOT_DIR not set — cannot resolve VITE_CONFIG_PATH");
+    return null;
+  }
+
+  const resolvedPath = resolve(rootDir, viteConfigPath);
+
+  try {
+    const loaded = await loadConfigFromFile(configEnv, resolvedPath);
+
+    if (!loaded) {
+      console.warn(`[celestite] No config exported from: ${resolvedPath}`);
+      return null;
+    }
+
+    console.log(`[celestite] Loaded user vite config from: ${resolvedPath}`);
+    return filterSveltePlugin(loaded.config);
+  } catch (e) {
+    console.error(`[celestite] Failed to load user vite config from ${resolvedPath}:`, e.message);
+    return null;
+  }
+}

--- a/src/svelte-scripts/vite-render-server.js
+++ b/src/svelte-scripts/vite-render-server.js
@@ -7,12 +7,9 @@ import {
 } from "fs";
 import { resolve, parse, join } from "path";
 import { fileURLToPath } from "url";
-import {
-  createServer as createViteServer,
-  loadConfigFromFile,
-  mergeConfig,
-} from "vite";
+import { createServer as createViteServer, mergeConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { loadUserViteConfig } from "./load-user-config.js";
 
 // Note: SSR bundles use absolute paths to celestite's svelte (configured in vite.config.js)
 // This ensures renderer and SSR components share the same svelte instance for ssr_context
@@ -261,31 +258,12 @@ function getDevHttpsConfig() {
 
 const devHttpsConfig = getDevHttpsConfig();
 
-// Load user's vite.config.js if VITE_CONFIG_PATH is provided
-async function loadUserViteConfig() {
-  const viteConfigPath = process.env.VITE_CONFIG_PATH;
-  if (!viteConfigPath) return null;
-
-  try {
-    const userConfig = await loadConfigFromFile(
-      { mode: dev ? "development" : "production" },
-      viteConfigPath,
-    );
-    console.log(`[vite-ssr] Loaded user vite config from: ${viteConfigPath}`);
-    return userConfig.config;
-  } catch (e) {
-    console.error(
-      `[vite-ssr] Failed to load user vite config from ${viteConfigPath}:`,
-      e.message,
-    );
-    return null;
-  }
-}
+const mode = dev ? "development" : "production";
 
 // Initialize Vite server for development SSR
 let vite = null;
 if (dev) {
-  const userConfig = await loadUserViteConfig();
+  const userConfig = await loadUserViteConfig({ mode, command: "serve", isSsrBuild: true });
 
   const baseConfig = {
     root: COMPONENT_DIR,
@@ -711,7 +689,7 @@ if (isProductionBuild) {
 
 // Also start Vite dev server for client HMR in development
 if (dev) {
-  const userConfig = await loadUserViteConfig();
+  const userConfig = await loadUserViteConfig({ mode, command: "serve", isSsrBuild: false });
 
   const clientBaseConfig = {
     root: COMPONENT_DIR,

--- a/src/svelte-scripts/vite-render-server.js
+++ b/src/svelte-scripts/vite-render-server.js
@@ -1,7 +1,17 @@
-import { readdirSync, statSync, readFileSync, existsSync, writeFileSync } from "fs";
+import {
+  readdirSync,
+  statSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+} from "fs";
 import { resolve, parse, join } from "path";
 import { fileURLToPath } from "url";
-import { createServer as createViteServer } from "vite";
+import {
+  createServer as createViteServer,
+  loadConfigFromFile,
+  mergeConfig,
+} from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 // Note: SSR bundles use absolute paths to celestite's svelte (configured in vite.config.js)
@@ -23,20 +33,27 @@ const {
 } = process.env;
 
 const disableA11yWarnings = DISABLE_A11Y_WARNINGS === "true";
-const bundledSvelteRoot = fileURLToPath(new URL("../../node_modules/svelte", import.meta.url));
+const bundledSvelteRoot = fileURLToPath(
+  new URL("../../node_modules/svelte", import.meta.url),
+);
 const rootDir = ROOT_DIR || process.cwd();
 const appSvelteRoot = resolve(rootDir, "node_modules", "svelte");
 const runtimeSvelteRoot = existsSync(join(appSvelteRoot, "package.json"))
   ? appSvelteRoot
   : bundledSvelteRoot;
-const svelteInternalClientCompatPath = join(runtimeSvelteRoot, "src/internal/client/celestite-compat.js");
+const svelteInternalClientCompatPath = join(
+  runtimeSvelteRoot,
+  "src/internal/client/celestite-compat.js",
+);
 
 // Development modes use Vite dev server; staging/production use pre-built assets
 const dev = NODE_ENV === "development" || NODE_ENV === "development_secure";
 const devSecure = NODE_ENV === "development_secure" || DEV_SECURE === "true";
 const devProtocol = devSecure ? "https" : "http";
 const devClientProtocol = DEV_CLIENT_PROTOCOL || devProtocol;
-const devClientBase = DEV_CLIENT_BASE ? normalizeDevClientBase(DEV_CLIENT_BASE) : null;
+const devClientBase = DEV_CLIENT_BASE
+  ? normalizeDevClientBase(DEV_CLIENT_BASE)
+  : null;
 // Staging mode uses production builds but with dev env vars loaded by Crystal
 const isProductionBuild = !dev; // staging and production both use pre-built assets
 
@@ -47,12 +64,16 @@ if (!dev && BUILD_DIR) {
   if (existsSync(manifestPath)) {
     try {
       manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
-      console.log(`[vite-ssr] Loaded production manifest with ${Object.keys(manifest).length} entries`);
+      console.log(
+        `[vite-ssr] Loaded production manifest with ${Object.keys(manifest).length} entries`,
+      );
     } catch (e) {
       console.error(`[vite-ssr] Failed to load manifest: ${e.message}`);
     }
   } else {
-    console.warn(`[vite-ssr] No manifest found at ${manifestPath} - run build first`);
+    console.warn(
+      `[vite-ssr] No manifest found at ${manifestPath} - run build first`,
+    );
   }
 }
 
@@ -111,7 +132,10 @@ function ensureSvelteCompatFile() {
   const compatSource = `export * from "./index.js";
 `;
 
-  if (!existsSync(svelteInternalClientCompatPath) || readFileSync(svelteInternalClientCompatPath, "utf-8") !== compatSource) {
+  if (
+    !existsSync(svelteInternalClientCompatPath) ||
+    readFileSync(svelteInternalClientCompatPath, "utf-8") !== compatSource
+  ) {
     writeFileSync(svelteInternalClientCompatPath, compatSource);
   }
 }
@@ -119,18 +143,41 @@ function ensureSvelteCompatFile() {
 function getSvelteResolveConfig(target = "client") {
   ensureSvelteCompatFile();
 
-  const entrypoint = target === "server" ? "index-server.js" : "index-client.js";
-  const legacyEntrypoint = target === "server" ? "legacy-server.js" : "legacy-client.js";
+  const entrypoint =
+    target === "server" ? "index-server.js" : "index-client.js";
+  const legacyEntrypoint =
+    target === "server" ? "legacy-server.js" : "legacy-client.js";
 
   return {
     alias: [
-      { find: /^svelte$/, replacement: join(runtimeSvelteRoot, `src/${entrypoint}`) },
-      { find: /^svelte\/internal\/client$/, replacement: svelteInternalClientCompatPath },
-      { find: /^svelte\/internal\/client\/index\.js$/, replacement: svelteInternalClientCompatPath },
-      { find: /^svelte\/store$/, replacement: join(runtimeSvelteRoot, `src/store/${entrypoint}`) },
-      { find: /^svelte\/reactivity$/, replacement: join(runtimeSvelteRoot, `src/reactivity/${entrypoint}`) },
-      { find: /^svelte\/legacy$/, replacement: join(runtimeSvelteRoot, `src/legacy/${legacyEntrypoint}`) },
-      { find: /^svelte\/(.+)$/, replacement: `${join(runtimeSvelteRoot, "src")}/$1` },
+      {
+        find: /^svelte$/,
+        replacement: join(runtimeSvelteRoot, `src/${entrypoint}`),
+      },
+      {
+        find: /^svelte\/internal\/client$/,
+        replacement: svelteInternalClientCompatPath,
+      },
+      {
+        find: /^svelte\/internal\/client\/index\.js$/,
+        replacement: svelteInternalClientCompatPath,
+      },
+      {
+        find: /^svelte\/store$/,
+        replacement: join(runtimeSvelteRoot, `src/store/${entrypoint}`),
+      },
+      {
+        find: /^svelte\/reactivity$/,
+        replacement: join(runtimeSvelteRoot, `src/reactivity/${entrypoint}`),
+      },
+      {
+        find: /^svelte\/legacy$/,
+        replacement: join(runtimeSvelteRoot, `src/legacy/${legacyEntrypoint}`),
+      },
+      {
+        find: /^svelte\/(.+)$/,
+        replacement: `${join(runtimeSvelteRoot, "src")}/$1`,
+      },
     ],
     dedupe: ["svelte"],
   };
@@ -214,10 +261,33 @@ function getDevHttpsConfig() {
 
 const devHttpsConfig = getDevHttpsConfig();
 
+// Load user's vite.config.js if VITE_CONFIG_PATH is provided
+async function loadUserViteConfig() {
+  const viteConfigPath = process.env.VITE_CONFIG_PATH;
+  if (!viteConfigPath) return null;
+
+  try {
+    const userConfig = await loadConfigFromFile(
+      { mode: dev ? "development" : "production" },
+      viteConfigPath,
+    );
+    console.log(`[vite-ssr] Loaded user vite config from: ${viteConfigPath}`);
+    return userConfig.config;
+  } catch (e) {
+    console.error(
+      `[vite-ssr] Failed to load user vite config from ${viteConfigPath}:`,
+      e.message,
+    );
+    return null;
+  }
+}
+
 // Initialize Vite server for development SSR
 let vite = null;
 if (dev) {
-  vite = await createViteServer({
+  const userConfig = await loadUserViteConfig();
+
+  const baseConfig = {
     root: COMPONENT_DIR,
     plugins: [getSveltePlugin()],
     server: { middlewareMode: true },
@@ -229,7 +299,12 @@ if (dev) {
     ssr: {
       noExternal: ["svelte"],
     },
-  });
+  };
+
+  const finalConfig = userConfig
+    ? mergeConfig(userConfig, baseConfig)
+    : baseConfig;
+  vite = await createViteServer(finalConfig);
 }
 
 const layoutFiles = loadLayoutFiles(LAYOUT_DIR);
@@ -263,11 +338,15 @@ async function collectComponentCss(componentPath) {
       const result = await vite.transformRequest(cssUrl);
       if (result?.code) {
         let css = "";
-        const viteMatch = result.code.match(/const __vite__css\s*=\s*"((?:[^"\\]|\\.)*)"/s);
+        const viteMatch = result.code.match(
+          /const __vite__css\s*=\s*"((?:[^"\\]|\\.)*)"/s,
+        );
         if (viteMatch) {
           css = viteMatch[1];
         } else {
-          const exportMatch = result.code.match(/export default\s*"((?:[^"\\]|\\.)*)"/s);
+          const exportMatch = result.code.match(
+            /export default\s*"((?:[^"\\]|\\.)*)"/s,
+          );
           if (exportMatch) {
             css = exportMatch[1];
           }
@@ -315,7 +394,8 @@ async function collectComponentCss(componentPath) {
     try {
       const source = readFileSync(filePath, "utf-8");
       const imports = [];
-      const importRegex = /import\s+[\w\s{},*]+\s+from\s+["']([^"']+\.svelte)["']/g;
+      const importRegex =
+        /import\s+[\w\s{},*]+\s+from\s+["']([^"']+\.svelte)["']/g;
       let match;
       while ((match = importRegex.exec(source)) !== null) {
         const importPath = match[1];
@@ -351,7 +431,9 @@ async function collectComponentCss(componentPath) {
   collectAllPaths(componentPath);
 
   // Fetch all CSS in parallel
-  const cssResults = await Promise.all(Array.from(visited).map((path) => getCssForComponent(path)));
+  const cssResults = await Promise.all(
+    Array.from(visited).map((path) => getCssForComponent(path)),
+  );
 
   return cssResults.filter((css) => css).join("\n");
 }
@@ -372,9 +454,10 @@ function findSvelteEntry() {
 // Generate client-side hydration script
 function generateClientScript(pathname, context, isDev, manifestEntry) {
   if (isDev) {
-    const viteBaseExpression = devClientBase && devClientBase !== "/"
-      ? `window.location.origin + '${devClientBase.slice(0, -1)}'`
-      : `'${devClientProtocol}://' + window.location.hostname + ':${VITE_PORT}'`;
+    const viteBaseExpression =
+      devClientBase && devClientBase !== "/"
+        ? `window.location.origin + '${devClientBase.slice(0, -1)}'`
+        : `'${devClientProtocol}://' + window.location.hostname + ':${VITE_PORT}'`;
 
     return `
       <script type="module">
@@ -397,11 +480,15 @@ function generateClientScript(pathname, context, isDev, manifestEntry) {
     `;
   } else {
     // Production: load from bundled assets using manifest
-    const jsFile = manifestEntry?.file || pathname.replace(/^\//, "").replace(/\.svelte$/, ".js");
+    const jsFile =
+      manifestEntry?.file ||
+      pathname.replace(/^\//, "").replace(/\.svelte$/, ".js");
     const svelteFile = findSvelteEntry();
 
     if (!svelteFile) {
-      console.error("[vite-ssr] No __svelte entry in manifest - client hydration will fail");
+      console.error(
+        "[vite-ssr] No __svelte entry in manifest - client hydration will fail",
+      );
     }
 
     // Assets built to BUILD_DIR/client/ are served at /client/ by Kemal
@@ -424,7 +511,8 @@ function generateClientScript(pathname, context, isDev, manifestEntry) {
 // Normalize component path
 function normalizeComponentPath(pathname) {
   // Handle root path
-  let normalized = pathname === "/" || pathname === "" ? "/index.svelte" : pathname;
+  let normalized =
+    pathname === "/" || pathname === "" ? "/index.svelte" : pathname;
   // Add .svelte extension if missing
   if (!normalized.endsWith(".svelte")) {
     normalized += ".svelte";
@@ -439,7 +527,9 @@ async function handleRender(req) {
   const layout = getLayout(layoutRequested, layoutFiles);
 
   if (!layout) {
-    return new Response(`Layout "${layoutRequested}" not found`, { status: 404 });
+    return new Response(`Layout "${layoutRequested}" not found`, {
+      status: 404,
+    });
   }
 
   // Get context from request body (POST) or empty object (GET)
@@ -470,16 +560,28 @@ async function handleRender(req) {
       render = svelteModule.render;
     } else {
       // Production: load pre-built SSR module
-      const ssrPath = join(BUILD_DIR, "server", pathname.replace(/\.svelte$/, ".js"));
-      const [componentModule, svelteModuleLoaded] = await Promise.all([import(ssrPath), import("svelte/server")]);
+      const ssrPath = join(
+        BUILD_DIR,
+        "server",
+        pathname.replace(/\.svelte$/, ".js"),
+      );
+      const [componentModule, svelteModuleLoaded] = await Promise.all([
+        import(ssrPath),
+        import("svelte/server"),
+      ]);
       component = componentModule.default;
       svelteModule = svelteModuleLoaded;
       render = svelteModule.render;
     }
   } catch (error) {
-    console.error(`[vite-ssr] Failed to load component ${pathname}:`, error.message);
+    console.error(
+      `[vite-ssr] Failed to load component ${pathname}:`,
+      error.message,
+    );
     console.error(error.stack);
-    return new Response(`Component load error: ${error.message}`, { status: 500 });
+    return new Response(`Component load error: ${error.message}`, {
+      status: 500,
+    });
   }
 
   // Render the component using Svelte 5's render() function
@@ -519,7 +621,12 @@ async function handleRender(req) {
     }
   }
 
-  const clientScript = generateClientScript(pathname, context, dev, manifestEntry);
+  const clientScript = generateClientScript(
+    pathname,
+    context,
+    dev,
+    manifestEntry,
+  );
 
   const html = layout
     .replace("<!-- CELESTITE HEAD -->", injectHead)
@@ -551,8 +658,12 @@ function scheduleIdleGc() {
       const before = process.memoryUsage();
       Bun.gc(true); // Synchronous full GC
       const after = process.memoryUsage();
-      const freedMB = Math.round((before.heapUsed - after.heapUsed) / 1024 / 1024);
-      console.log(`[vite-ssr] Idle GC freed ${freedMB}MB (heap: ${Math.round(after.heapUsed / 1024 / 1024)}MB)`);
+      const freedMB = Math.round(
+        (before.heapUsed - after.heapUsed) / 1024 / 1024,
+      );
+      console.log(
+        `[vite-ssr] Idle GC freed ${freedMB}MB (heap: ${Math.round(after.heapUsed / 1024 / 1024)}MB)`,
+      );
     }
     idleGcTimer = null;
   }, IDLE_GC_DELAY_MS);
@@ -577,7 +688,9 @@ const server = Bun.serve({
     const response = await handleRender(req);
 
     const duration = (performance.now() - start).toFixed(2);
-    console.log(`[vite-ssr] ${req.method} ${url.pathname} ${response.status} - ${duration}ms`);
+    console.log(
+      `[vite-ssr] ${req.method} ${url.pathname} ${response.status} - ${duration}ms`,
+    );
 
     // Decrement and schedule GC when idle
     requestsInFlight--;
@@ -587,15 +700,20 @@ const server = Bun.serve({
   },
 });
 
-console.log(`[vite-ssr] Svelte SSR renderer listening in ${NODE_ENV} mode on port ${server.port}`);
+console.log(
+  `[vite-ssr] Svelte SSR renderer listening in ${NODE_ENV} mode on port ${server.port}`,
+);
 if (isProductionBuild) {
-  console.log(`[vite-ssr] Idle GC enabled: will run after ${IDLE_GC_DELAY_MS}ms of inactivity`);
+  console.log(
+    `[vite-ssr] Idle GC enabled: will run after ${IDLE_GC_DELAY_MS}ms of inactivity`,
+  );
 }
 
 // Also start Vite dev server for client HMR in development
 if (dev) {
-  // Start Vite's HTTP server for serving client assets with HMR
-  const viteClientServer = await createViteServer({
+  const userConfig = await loadUserViteConfig();
+
+  const clientBaseConfig = {
     root: COMPONENT_DIR,
     base: devClientBase || "/",
     plugins: [getSveltePlugin()],
@@ -611,7 +729,15 @@ if (dev) {
       https: devHttpsConfig,
       cors: true, // Allow cross-origin requests from the main app
     },
-  });
+  };
+
+  const clientFinalConfig = userConfig
+    ? mergeConfig(userConfig, clientBaseConfig)
+    : clientBaseConfig;
+  // Start Vite's HTTP server for serving client assets with HMR
+  const viteClientServer = await createViteServer(clientFinalConfig);
   await viteClientServer.listen();
-  console.log(`[vite-ssr] Vite dev server running on ${devProtocol}://localhost:${VITE_PORT}`);
+  console.log(
+    `[vite-ssr] Vite dev server running on ${devProtocol}://localhost:${VITE_PORT}`,
+  );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadConfigFromFile, mergeConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { readdirSync, statSync } from "fs";
 import { resolve, relative, dirname } from "path";
@@ -53,14 +53,30 @@ function createEntryPoints(componentDir, isSsrBuild) {
   return entries;
 }
 
-export default defineConfig(({ command, isSsrBuild }) => {
+export default defineConfig(async ({ command, isSsrBuild }) => {
   const isDev = command === "serve";
   const componentDir = process.env.COMPONENT_DIR;
   const buildDir = process.env.BUILD_DIR;
+  const viteConfigPath = process.env.VITE_CONFIG_PATH;
 
   const entries = componentDir ? createEntryPoints(componentDir, isSsrBuild) : {};
 
-  return {
+  // Load user's vite config if provided
+  let userConfig = null;
+  if (viteConfigPath) {
+    try {
+      const loaded = await loadConfigFromFile(
+        { mode: isDev ? "development" : "production" },
+        viteConfigPath
+      );
+      userConfig = loaded.config;
+      console.log(`[celestite] Loaded user vite config from: ${viteConfigPath}`);
+    } catch (e) {
+      console.error(`[celestite] Failed to load user vite config from ${viteConfigPath}:`, e.message);
+    }
+  }
+
+  const baseConfig = {
     root: componentDir || process.cwd(),
     plugins: [
       svelte({
@@ -126,4 +142,6 @@ export default defineConfig(({ command, isSsrBuild }) => {
       // to celestite's svelte package so renderer and components share the same ssr_context.
     },
   };
+
+  return userConfig ? mergeConfig(userConfig, baseConfig) : baseConfig;
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,9 @@
-import { defineConfig, loadConfigFromFile, mergeConfig } from "vite";
+import { defineConfig, mergeConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { readdirSync, statSync } from "fs";
 import { resolve, relative, dirname } from "path";
 import { fileURLToPath } from "url";
+import { loadUserViteConfig } from "./src/svelte-scripts/load-user-config.js";
 
 // Get celestite's root directory (where vite.config.js is located)
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -57,24 +58,15 @@ export default defineConfig(async ({ command, isSsrBuild }) => {
   const isDev = command === "serve";
   const componentDir = process.env.COMPONENT_DIR;
   const buildDir = process.env.BUILD_DIR;
-  const viteConfigPath = process.env.VITE_CONFIG_PATH;
 
   const entries = componentDir ? createEntryPoints(componentDir, isSsrBuild) : {};
 
-  // Load user's vite config if provided
-  let userConfig = null;
-  if (viteConfigPath) {
-    try {
-      const loaded = await loadConfigFromFile(
-        { mode: isDev ? "development" : "production" },
-        viteConfigPath
-      );
-      userConfig = loaded.config;
-      console.log(`[celestite] Loaded user vite config from: ${viteConfigPath}`);
-    } catch (e) {
-      console.error(`[celestite] Failed to load user vite config from ${viteConfigPath}:`, e.message);
-    }
-  }
+  // Load user's vite config via shared module
+  const userConfig = await loadUserViteConfig({
+    mode: isDev ? "development" : "production",
+    command,
+    isSsrBuild
+  });
 
   const baseConfig = {
     root: componentDir || process.cwd(),


### PR DESCRIPTION
this PR adds support for loading a user provided `vite.config.js` and merging it with Celestite's base Vite configuration. Users can now add Vite plugins like Tailwind CSS by setting the `vite_config_path` option. The config merging applies to the dev SSR server, client HMR server, and production builds.